### PR TITLE
Add secp256k1_ecdh_raw().

### DIFF
--- a/include/secp256k1_ecdh.h
+++ b/include/secp256k1_ecdh.h
@@ -24,6 +24,24 @@ SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_ecdh(
   const unsigned char *privkey
 ) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3) SECP256K1_ARG_NONNULL(4);
 
+/** Compute an EC Diffie-Hellman secret in constant time
+ *  Returns: 1: exponentiation was successful
+ *           0: scalar was invalid (zero or overflow)
+ *  Args:    ctx:        pointer to a context object (cannot be NULL)
+ *  Out:     result:     a 33-byte array which will be populated by an ECDH
+ *                       secret computed from the point and scalar in form
+ *                       of compressed point
+ *  In:      pubkey:     a pointer to a secp256k1_pubkey containing an
+ *                       initialized public key
+ *           privkey:    a 32-byte scalar with which to multiply the point
+ */
+SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_ecdh_raw(
+  const secp256k1_context* ctx,
+  unsigned char *result,
+  const secp256k1_pubkey *pubkey,
+  const unsigned char *privkey
+) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3) SECP256K1_ARG_NONNULL(4);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/modules/ecdh/main_impl.h
+++ b/src/modules/ecdh/main_impl.h
@@ -51,4 +51,36 @@ int secp256k1_ecdh(const secp256k1_context* ctx, unsigned char *result, const se
     return ret;
 }
 
+int secp256k1_ecdh_raw(const secp256k1_context* ctx, unsigned char *result, const secp256k1_pubkey *point, const unsigned char *scalar) {
+    int ret = 0;
+    int overflow = 0;
+    secp256k1_gej res;
+    secp256k1_ge pt;
+    secp256k1_scalar s;
+    VERIFY_CHECK(ctx != NULL);
+    ARG_CHECK(result != NULL);
+    ARG_CHECK(point != NULL);
+    ARG_CHECK(scalar != NULL);
+
+    secp256k1_pubkey_load(ctx, &pt, point);
+    secp256k1_scalar_set_b32(&s, scalar, &overflow);
+    if (overflow || secp256k1_scalar_is_zero(&s)) {
+        ret = 0;
+    } else {
+        secp256k1_ecmult_const(&res, &pt, &s);
+        secp256k1_ge_set_gej(&pt, &res);
+        /* Output the point in compressed form.
+         * Note we cannot use secp256k1_eckey_pubkey_serialize here since it does not
+         * expect its output to be secret and has a timing sidechannel. */
+        secp256k1_fe_normalize(&pt.x);
+        secp256k1_fe_normalize(&pt.y);
+        result[0] = 0x02 | secp256k1_fe_is_odd(&pt.y);
+        secp256k1_fe_get_b32(&result[1], &pt.x);
+        ret = 1;
+    }
+
+    secp256k1_scalar_clear(&s);
+    return ret;
+}
+
 #endif /* SECP256K1_MODULE_ECDH_MAIN_H */


### PR DESCRIPTION
This will allow implement ECDH which can pass all tests. Without this change we need to implement whole ECC secp256k1, because needed functions are not exported by `libsecp256k1`.